### PR TITLE
Remove illegal const constructors.

### DIFF
--- a/lib/perf_api.dart
+++ b/lib/perf_api.dart
@@ -9,12 +9,6 @@ class Profiler {
   final Counters counters = new Counters();
 
   /**
-   * Const constructor allows instances of this class to be used as a no-op
-   * implementation.
-   */
-  const Profiler();
-
-  /**
    * Starts a new timer for a given action [name]. A timer id will be
    * returned which can be used in [stopTimer] to stop the timer.
    *
@@ -72,8 +66,6 @@ class Profiler {
 class Counters {
 
   final Map<String, int> _counters = <String, int>{};
-
-  const Counters();
 
   /**
    * Increments the counter under [counterName] by [delta]. Default [delta]

--- a/test/perf_api_test.dart
+++ b/test/perf_api_test.dart
@@ -7,10 +7,6 @@ import 'package:perf_api/perf_api.dart';
 
 main() {
 
-  test('should be able to instantiate as a noop profiler', () {
-    expect(() => new Profiler(), returnsNormally);
-  });
-
   group('Default Impl', () {
     Profiler perf;
 


### PR DESCRIPTION
Remove test of default constructor, which seems unnecessary.

Fixes #4 and #5
