### PR TITLE
feat(Console Profiler): Allow multiple timers with the same name

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,5 +4,8 @@ author: Pavel Jbanov <pavelgj@gmail.com>
 homepage: https://github.com/google/perf_api.dart
 description: A simple profiling instrumentation API
 
+dependencies:
+  quiver: '>=0.18.2 <0.19.0'
+
 dev_dependencies:
   unittest: '>=0.9.0 <0.12.0'


### PR DESCRIPTION
@pavelgj does "// TODO: change this to use a multimap." means that we want to support multiple timers with the same name ?

If this is the case this is what I implemented in this PR. It passes smoke tests but I'll write unit tests once you confirm the expected behavior.

ref smoke test
```dart
  var profiler = new ConsoleProfiler();

  profiler.startTimer('foo', '1');
  profiler.startTimer('bar', '1');
  profiler.startTimer('foo', '2');

  profiler.stopTimer('foo');
  profiler.stopTimer('bar');
```